### PR TITLE
better method for local and remote dependencies implemented with extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ __pycache__/
 *.pdb
 *.egg-info/
 .venv/
+#build files
+build/
+dist/
 # uv files
 uv.lock

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Clone and run the `example.py` script directly:
 git clone https://github.com/WrapTools/WrapAI.git
 cd WrapAI
 # Run the script using remote dependencies
-uv run examples/example.py
+uv run --with ".[wrapdeps-remote]" examples/example.py
 # Or developer mode with dependencies on a local install:
-uv run --with "../WrapDataclass" examples/example.py
+uv run --with ".[wrapdeps-local]" examples/example.py
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,25 @@ requires-python = ">=3.13"
 dependencies = [
     "requests>=2.31.0",
     "tiktoken>=0.8.0",
-    "wrapdataclass",
 ]
+
+[project.optional-dependencies]
+wrapdeps-remote = ["wrapdataclass"]
+wrapdeps-local = ["wrapdataclass"]
 
 [tool.setuptools]
 include-package-data = true
 
+[tool.uv]
+conflicts = [
+    [
+        { extra = "wrapdeps-remote" },
+        { extra = "wrapdeps-local" },
+    ]
+]
+
 [tool.uv.sources]
-wrapdataclass = { git = "https://github.com/taxman20000/WrapDataclass.git"}
+"wrapdataclass" = [
+    { git = "https://github.com/taxman20000/WrapDataclass.git", extra = "wrapdeps-remote"},
+    { path = "../WrapDataclass", extra = "wrapdeps-local"}
+]


### PR DESCRIPTION
- Run with with `wrapai[wrapdeps-remote]` to install `WrapDataclass` dependency from GitHub repo.
- Run with with `wrapai[wrapdeps-local]` to install `WrapDataclass` dependency from local drive.